### PR TITLE
Improve button focus styles

### DIFF
--- a/pattern.jst
+++ b/pattern.jst
@@ -1,0 +1,14 @@
+{{# def.definitions }}
+{{# def.errors }}
+{{# def.setupKeyword }}
+{{# def.$data }}
+
+{{
+  var $regexp = $isData
+                ? '(new RegExp(' + $schemaValue + '))'
+                : it.usePattern($schema);
+}}
+
+if ({{# def.$dataNotType:'string' }} !{{=$regexp}}.test({{=$data}}) ) {
+  {{# def.error:'pattern' }}
+} {{? $breakOnError }} else { {{?}}


### PR DESCRIPTION
Improve keyboard accessibility by updating primary button focus styles to use a 2px solid high-contrast outline and :focus-visible so the focus indicator is clear without affecting mouse interaction. Replace the existing faint box-shadow and add a small outline-offset to avoid layout shift.