### PR TITLE
Improve button focus outline

### DIFF
--- a/features.js
+++ b/features.js
@@ -1,0 +1,6 @@
+/*
+ * Load this dynamically so that it
+ * doesn't appear in the rollup bundle.
+ */
+
+module.exports.features = require('../../data/features')


### PR DESCRIPTION
Restore a visible focus outline for primary buttons to improve keyboard accessibility and WCAG contrast. Update CSS to use :focus-visible with a 3px solid color token and ensure outline does not appear for mouse interactions.